### PR TITLE
feat: ocr api 호출 후 데이터 반환 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,19 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//implementation group: 'org.json', name: 'json', version: '20231013'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	//testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/CheckController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/CheckController.java
@@ -1,0 +1,73 @@
+package likelion12th.SwuniForest.presentation.controller;
+
+import likelion12th.SwuniForest.service.user.ClovaOcrApi;
+import likelion12th.SwuniForest.service.user.domain.MemberRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.ResourceUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class CheckController { // 배포 후에 로컬 경로가 아닌 s3 버킷으로 변경 필요
+
+//    // AWS S3 관련 설정
+//    @Value("${aws.s3.bucketName}")
+//    private String bucketName;
+//    private final AmazonS3 amazonS3;
+
+    private final ClovaOcrApi ocrApi;
+    @Value("${naver.service.secretKey}")
+    private String secretKey;
+
+    @Value("${uploadPath}")
+    private String uploadPath;
+
+    @PostMapping("/naverOcrPost")
+    public ResponseEntity ocr(@RequestParam("file") MultipartFile file) throws IOException {
+        if (file.isEmpty()) {
+            return new ResponseEntity("No file uploaded", HttpStatus.BAD_REQUEST);
+        }
+
+        String fileName = file.getOriginalFilename();
+        String filePath = uploadPath + "/" + fileName;
+
+        // MultipartFile -> File 변환 후 저장
+        file.transferTo(new File(filePath));
+
+        // 방금 저장한 파일 불러오기
+        File savedFile = ResourceUtils.getFile(filePath);
+        // 요청받은 파일의 확장자를 file.getContentType() 으로 조회하면 PNG같은 확장자가 아닌 multipart/form-data 로 들어가서 OCR API 호출 시 400 에러가 발생한다.
+        // 저장한 File 객체의 확장자를 불러오기 위해 지정된 메소드가 없기 떄문에 살짝은.. 끼워맞추기 식으로 문자열 추출을 하였다.
+        String ext = "";
+
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex > 0) {
+            ext = fileName.substring(lastDotIndex + 1);
+        }
+
+        // OCR API 호출
+        MemberRes memberRes = ocrApi.callApi("POST", savedFile.getPath(), secretKey, ext);
+
+        // OCR 결과 처리
+        if (memberRes != null) {
+            return new ResponseEntity(memberRes, HttpStatus.OK);
+        } else {
+            log.info("OCR failed");
+            return new ResponseEntity("OCR failed", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}
+

--- a/src/main/java/likelion12th/SwuniForest/service/user/ClovaOcrApi.java
+++ b/src/main/java/likelion12th/SwuniForest/service/user/ClovaOcrApi.java
@@ -1,0 +1,175 @@
+package likelion12th.SwuniForest.service.user;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import likelion12th.SwuniForest.service.user.domain.MemberRes;
+import likelion12th.SwuniForest.utill.JsonUtill;
+import lombok.extern.slf4j.Slf4j;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ClovaOcrApi {
+    @Value("${naver.service.url}")
+    private String url;
+
+    /**
+     * 네이버 ocr api 호출한다
+     * @param {string} type 호출 메서드 타입
+     * @param {string} filePath 파일 경로
+     * @param {string} naver_secretKey 네이버 시크릿키 값
+     * @param {string} ext 확장자
+     * @returns {List} 추출 text list
+     */
+    public MemberRes callApi(String type, String filePath, String naver_secretKey, String ext) {
+        String apiURL = url;
+        String secretKey = naver_secretKey;
+        String imageFile = filePath;
+        List<String> parseData = null;
+
+        log.info("callApi Start!");
+
+        MemberRes memberRes = null;
+        try {
+            URL url = new URL(apiURL);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setUseCaches(false);
+            con.setDoInput(true);
+            con.setDoOutput(true);
+            con.setReadTimeout(30000);
+            con.setRequestMethod(type);
+            String boundary = "----" + UUID.randomUUID().toString().replaceAll("-", "");
+            con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+            con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary); // HTTP 요청 헤더를 설정합니다.
+            con.setRequestProperty("X-OCR-SECRET", secretKey); // 시크릿 키를 설정합니다.
+
+            JSONObject json = new JSONObject(); // JSON 객체 생성
+            json.put("version", "V2"); // JSON 객체에 버전 정보 추가
+            json.put("requestId", UUID.randomUUID().toString()); // JSON 객체에 요청 ID 추가
+            json.put("timestamp", System.currentTimeMillis()); // JSON 객체에 타임스탬프 추가
+            JSONObject image = new JSONObject(); // JSON 객체 생성
+            image.put("format", ext); // 이미지 형식 정보 추가
+            image.put("name", "demo"); // 이미지 이름 추가
+            JSONArray images = new JSONArray(); // JSON 배열 생성
+            images.add(image); // JSON 배열에 이미지 정보 추가
+            json.put("images", images); // JSON 객체에 이미지 배열 추가
+            String postParams = json.toString(); // JSON 객체를 문자열로 변환
+
+            con.connect();
+            DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+            File file = new File(imageFile);
+            writeMultiPart(wr, postParams, file, boundary);
+            wr.close();
+
+            int responseCode = con.getResponseCode();
+            BufferedReader br;
+            if (responseCode == 200) {
+                br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+            }
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+            while ((inputLine = br.readLine()) != null) {
+                response.append(inputLine);
+            }
+            br.close();
+
+            // 데이터 리스트로 가공
+            parseData = jsonparse(response);
+
+            // 가공한 데이터 dto 변환
+            memberRes = MemberRes.builder()
+                    .studentNum(parseData.get(0))
+                    .name(parseData.get(1))
+                    .major(parseData.get(2))
+                    .build();
+
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+        return memberRes;
+    }
+
+    /**
+     * writeMultiPart
+     * @param {OutputStream} out 데이터를 출력
+     * @param {string} jsonMessage 요청 params
+     * @param {File} file 요청 파일
+     * @param {String} boundary 경계
+     */
+    private static void writeMultiPart(OutputStream out, String jsonMessage, File file, String boundary) throws
+            IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("--").append(boundary).append("\r\n");
+        sb.append("Content-Disposition:form-data; name=\"message\"\r\n\r\n");
+        sb.append(jsonMessage);
+        sb.append("\r\n");
+
+        out.write(sb.toString().getBytes("UTF-8"));
+        out.flush();
+
+        if (file != null && file.isFile()) {
+            out.write(("--" + boundary + "\r\n").getBytes("UTF-8"));
+            StringBuilder fileString = new StringBuilder();
+            fileString
+                    .append("Content-Disposition:form-data; name=\"file\"; filename=");
+            fileString.append("\"" + file.getName() + "\"\r\n");
+            fileString.append("Content-Type: application/octet-stream\r\n\r\n");
+            out.write(fileString.toString().getBytes("UTF-8"));
+            out.flush();
+
+            try (FileInputStream fis = new FileInputStream(file)) {
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = fis.read(buffer)) != -1) {
+                    out.write(buffer, 0, count);
+                }
+                out.write("\r\n".getBytes());
+            }
+
+            out.write(("--" + boundary + "--\r\n").getBytes("UTF-8"));
+        }
+        out.flush();
+    }
+    /**
+     * 데이터 가공
+     * @param {StringBuffer} response 응답값
+     * @returns {List} result text list
+     */
+    private static List<String> jsonparse(StringBuffer response) throws ParseException {
+        // json 파싱
+        JSONParser jp = new JSONParser();
+        JSONObject jobj = (JSONObject) jp.parse(response.toString());
+        // images 배열 객체로 변환
+        JSONArray JSONArrayPerson = (JSONArray)jobj.get("images");
+        JSONObject JSONObjImage = (JSONObject)JSONArrayPerson.get(0);
+        JSONArray s = (JSONArray) JSONObjImage.get("fields");
+        //
+        List<Map<String, Object>> m = JsonUtill.getListMapFromJsonArray(s);
+        List<String> result = new ArrayList<>();
+        for (Map<String, Object> as : m) {
+            result.add((String) as.get("inferText"));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/likelion12th/SwuniForest/service/user/domain/Member.java
+++ b/src/main/java/likelion12th/SwuniForest/service/user/domain/Member.java
@@ -1,0 +1,26 @@
+package likelion12th.SwuniForest.service.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_id")
+    private Long id;
+
+    // 학번
+    private String studentNum;
+
+    // 이름
+    private String name;
+
+    // 학과
+    private String major;
+
+    // 비밀번호
+    private String password;
+}

--- a/src/main/java/likelion12th/SwuniForest/service/user/domain/MemberReq.java
+++ b/src/main/java/likelion12th/SwuniForest/service/user/domain/MemberReq.java
@@ -1,0 +1,11 @@
+package likelion12th.SwuniForest.service.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public class MemberReq { // 회원가입 시 요청
+    private String studentNum;
+    private String name;
+    private String major;
+    private String password;
+}

--- a/src/main/java/likelion12th/SwuniForest/service/user/domain/MemberRes.java
+++ b/src/main/java/likelion12th/SwuniForest/service/user/domain/MemberRes.java
@@ -1,0 +1,12 @@
+package likelion12th.SwuniForest.service.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberRes { // ocr api 호출 후 데이터 응답
+    private String studentNum;
+    private String name;
+    private String major;
+}

--- a/src/main/java/likelion12th/SwuniForest/utill/JsonUtill.java
+++ b/src/main/java/likelion12th/SwuniForest/utill/JsonUtill.java
@@ -1,0 +1,58 @@
+package likelion12th.SwuniForest.utill;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class JsonUtill {
+    /**
+     * JSONObject => Map<String, String>
+     * @param {JSONObject} jsonObject
+     * @returns {Map} map
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> getMapFromJsonObject(JSONObject jsonObject) {
+        Map<String, Object> map = null;
+        try {
+            map = new ObjectMapper().readValue(jsonObject.toJSONString(), Map.class);
+
+        } catch (JsonParseException e) {
+            e.printStackTrace();
+        } catch (JsonMappingException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return map;
+    }
+    /**
+     * JSONArray => List<Map<String, String>>
+     * @param {jsonArray} jsonArray
+     * @returns {List} list
+     */
+    public static List<Map<String, Object>> getListMapFromJsonArray(JSONArray jsonArray) {
+
+        List<Map<String, Object>> list = new ArrayList<Map<String, Object>>();
+
+        if (jsonArray != null) {
+
+            int jsonSize = jsonArray.size();
+
+            for (int i = 0; i < jsonSize; i++) {
+
+                Map<String, Object> map = getMapFromJsonObject((JSONObject)jsonArray.get(i));
+                list.add(map);
+
+            }
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
현재 post로 이미지 request param에 담아서 보내면 resources/static/image 저장하도록 작성되어있으므로 
application.properties에 아래의 uploadPath 로컬 경로 지정해주기

```
uploadPath=~~~~/src/main/resources/static/image
```
** 추후 배포 시 파일 서버에 저장하도록 수정할 예정