### PR TITLE
feat: 방문하기, 로그인 로직 수정 및 추가

### DIFF
--- a/src/main/java/likelion12th/SwuniForest/config/CorsConfig.java
+++ b/src/main/java/likelion12th/SwuniForest/config/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 
-        source.registerCorsConfiguration("/api/**", config);
+        source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/config/SecurityConfig.java
+++ b/src/main/java/likelion12th/SwuniForest/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package likelion12th.SwuniForest.config;
 import likelion12th.SwuniForest.jwt.*;
 import likelion12th.SwuniForest.service.member.CustomUserDetailsService;
 import lombok.AllArgsConstructor;
+import org.apache.catalina.filters.CorsFilter;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -26,8 +32,8 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final CustomUserDetailsService customUserDetailsService;
-    private static final String [] AUTH_WHITELIST = {
-            "/login", "/signup", "/naverOcrPost", "/user"
+    private static final String[] AUTH_WHITELIST = {
+            "/api/login", "/api/signup", "/api/naverOcrPost", "/api/user"
     };
 
     @Bean
@@ -39,7 +45,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 // token을 사용하는 방식이기 때문에 csrf를 disable
-                .csrf((csrf)->csrf.disable())
+                .csrf((csrf) -> csrf.disable())
                 .cors(Customizer.withDefaults())
 
 

--- a/src/main/java/likelion12th/SwuniForest/db/DbInit.java
+++ b/src/main/java/likelion12th/SwuniForest/db/DbInit.java
@@ -31,7 +31,16 @@ public class DbInit {
                 "dep29", "dep30", "dep31", "dep32", "dep33", "dep34", "dep35"
         };
 
-        // 폼으로 입력하는게 아니라서.. 미리 선언
+        // 학과별 비밀번호 리스트
+        String [] passwordList = {
+            "8fnSkODZ", "IqriN419", "VJezcA8O", "b49GAQyt", "VQwse9s2", "lDmYe729", "ND2mBtcz", "7XZO46Js",
+            "b5FTmB6k", "BRxo8sou", "MMlxy51k", "pvvsgAMN", "W2Y7qeY1", "0EGI2duF", "XBIvxwTf", "6lrAqPyW",
+            "KNZ6clpT", "Tf7AThSJ", "cB4r6QjC", "3lPbdfdg", "TVUY5TP6", "Y1XOvaff", "RVTrr4tn", "HZOsJSJQ",
+            "N00F9nG9", "iLIEint5", "Nop88W0M", "aAa7vp4w", "CAkg4oXU", "O7uIo7W5", "9Smt72zZ", "Se9dpdBv",
+            "stC1lTlZ", "2KidIg3Q", "3mludySU"
+        };
+
+
         String adminPassword = "likelion1212!!";
 
         // 최상위 관리자 계정 생성
@@ -52,6 +61,7 @@ public class DbInit {
                     .visitor(0L)
                     .totalStudent(100L)
                     .visitRate(0L)
+                    .ranking(0)
                     .build();
 
             visitRepository.save(visit);
@@ -60,28 +70,11 @@ public class DbInit {
             Member manager = Member.builder()
                     .studentNum(majorList[i]) // 영문학과명 + 숫자로 수정
                     .major(majorList[i])
-                    .password(generateRandomString(8))
+                    .password(passwordEncoder.encode(passwordList[i]))
                     .role(Role.ROLE_MANAGER)
                     .build();
 
             memberRepository.save(manager);
         }
     }
-
-    // 랜덤 스트링 생성 메소드
-    private String generateRandomString(int length) {
-        String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-        Random random = new Random();
-        StringBuilder sb = new StringBuilder(length);
-
-        for (int i = 0; i < length; i++) {
-            int randomIndex = random.nextInt(CHARACTERS.length());
-            sb.append(CHARACTERS.charAt(randomIndex));
-        }
-
-        return sb.toString();
-    }
-
-
 }

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/member/AuthController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/member/AuthController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class AuthController {
 
     private final AuthService authService;
@@ -30,8 +31,8 @@ public class AuthController {
     public ResponseEntity<TokenDto> authorize(@Valid @RequestBody LoginDto loginDto) {
         try {
             // tokenDto를 이용해 response body에도 넣어서 리턴
-            String token = this.authService.login(loginDto);
-            return new ResponseEntity<>(new TokenDto(token), HttpStatus.OK);
+            TokenDto tokenDto = authService.login(loginDto);
+            return new ResponseEntity<>(tokenDto, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/member/MemberController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/member/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@RequestMapping("/api")
 public class MemberController {
     private final MemberService memberService;
 

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/member/OcrController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/member/OcrController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +17,7 @@ import java.io.*;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class OcrController {
 
     private final ClovaOcrApiService clovaOcrApiService;

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
@@ -1,19 +1,22 @@
-package likelion12th.SwuniForest.presentation.controller.member;
+package likelion12th.SwuniForest.presentation.controller.visit;
 
 import likelion12th.SwuniForest.service.member.MemberService;
 import likelion12th.SwuniForest.service.visit.VisitService;
 import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@RequestMapping("/api")
 public class VisitController {
 
     private final MemberService memberService;
@@ -22,18 +25,16 @@ public class VisitController {
     // 방문하기
     @GetMapping("/visit")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    public ResponseEntity<String> visited() {
+    public ResponseEntity visited() {
         MemberResDto memberResDto = memberService.getMyMemberInfo();
 
         // 이미 방문하기 눌렀다면
         if (memberResDto.getVisited()) {
-            return new ResponseEntity("이미 방문하기를 누르셨습니다.", HttpStatus.OK);
+            return new ResponseEntity("이미 방문하기를 누르셨습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         } else {
-            // 특정 학과 방문자 수 증가
-            visitService.update_visitRate(memberResDto.getMajor());
-            // 요청한 사용자 방문 여부 필드 false 로 변경
-            memberService.update_visited(memberResDto.getStudentNum());
-            return new ResponseEntity("방문하기 성공", HttpStatus.OK);
+            VisitResDto visitResDto = visitService.update_visit(memberResDto);
+            // 방문하기 성공하면 방문율 데이터 dto 리턴
+            return new ResponseEntity(visitResDto, HttpStatus.OK);
         }
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/member/AuthService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/member/AuthService.java
@@ -1,9 +1,10 @@
 package likelion12th.SwuniForest.service.member;
 
 import likelion12th.SwuniForest.service.member.domain.dto.LoginDto;
+import likelion12th.SwuniForest.service.member.domain.dto.TokenDto;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface AuthService {
     @Transactional
-    String login(LoginDto loginDto);
+    TokenDto login(LoginDto loginDto);
 }

--- a/src/main/java/likelion12th/SwuniForest/service/member/AuthServiceImpl.java
+++ b/src/main/java/likelion12th/SwuniForest/service/member/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import likelion12th.SwuniForest.jwt.TokenProvider;
 import likelion12th.SwuniForest.service.member.domain.Member;
 import likelion12th.SwuniForest.service.member.domain.dto.CustomUserInfoDto;
 import likelion12th.SwuniForest.service.member.domain.dto.LoginDto;
+import likelion12th.SwuniForest.service.member.domain.dto.TokenDto;
 import likelion12th.SwuniForest.service.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -25,29 +26,25 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public String login(LoginDto loginDto) {
+    public TokenDto login(LoginDto loginDto) {
         String studentNum = loginDto.getStudentNum();
         String password = loginDto.getPassword();
         Optional<Member> optionalMember = memberRepository.findByStudentNum(studentNum);
 
         // optionalMember가 존재하지 않는 경우 예외 발생
-        Member member = optionalMember.orElseThrow(() -> new UsernameNotFoundException("해당 회원이 존재하지 않습니다."));
+        Member member = optionalMember.orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
 
-        if (member.getUsername() == null) {
-            if (!password.equals(member.getPassword())) {
-                throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
-            }
-
-            return createAccessToken(member);
-        } else {
-            // 암호화된 password를 디코딩한 값과 입력한 패스워드 값이 다르면 null 반환
-            if (!encoder.matches(password, member.getPassword())) {
-                throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
-            }
-
-            return createAccessToken(member);
+        // 비밀번호 비교 후 일치 시 토큰 반환
+        if (!encoder.matches(password, member.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
+        TokenDto tokenDto = TokenDto.builder()
+                .token(createAccessToken(member))
+                .role(member.getRole().toString())
+                .build();
+
+        return tokenDto;
     }
 
     private String createAccessToken(Member member) {

--- a/src/main/java/likelion12th/SwuniForest/service/member/MemberService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/member/MemberService.java
@@ -45,11 +45,8 @@ public class MemberService {
                 .build();
 
         member.getStamp().setMember(member); // 서윤 추가
-        log.info("유저 생성");
-
         memberRepository.save(member);
 
-        log.info("유저 저장");
 
         // entity -> dto 변환
         MemberResDto memberResDto = MemberResDto.builder()
@@ -117,20 +114,5 @@ public class MemberService {
 
     }
 
-    public void update_visited(String studentNum) {
-        Optional<Member> memberOptional = memberRepository.findByStudentNum(studentNum);
 
-        // 조회한 회원이 존재한다면
-        if (memberOptional.isPresent()) {
-            // member 객체 가져오기
-            Member member = memberOptional.get();
-
-            // 방문 여부 true로 변경
-            member.visited();
-            memberRepository.save(member);
-
-        } else { // 회원이 존재하지 않는 경우
-            throw new RuntimeException("존재하지 않는 회원입니다.");
-        }
-    }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/member/domain/dto/TokenDto.java
+++ b/src/main/java/likelion12th/SwuniForest/service/member/domain/dto/TokenDto.java
@@ -10,4 +10,5 @@ import lombok.*;
 public class TokenDto {
 
     private String token;
+    private String role;
 }

--- a/src/main/java/likelion12th/SwuniForest/service/visit/VisitService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/VisitService.java
@@ -1,30 +1,90 @@
 package likelion12th.SwuniForest.service.visit;
 
+import likelion12th.SwuniForest.service.member.MemberService;
+import likelion12th.SwuniForest.service.member.domain.Member;
+import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
+import likelion12th.SwuniForest.service.member.repository.MemberRepository;
 import likelion12th.SwuniForest.service.visit.domain.Visit;
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import likelion12th.SwuniForest.service.visit.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class VisitService {
 
+    private final MemberRepository memberRepository;
     private final VisitRepository visitRepository;
 
-    // 방문율 업데이트
-    public void update_visitRate(String major) {
-        Optional visitOptional = visitRepository.findByMajor(major);
+    // 방문하기
+    public VisitResDto update_visit(MemberResDto memberResDto) {
+        Optional visitOptional = visitRepository.findByMajor(memberResDto.getMajor());
+        Optional<Member> memberOptional = memberRepository.findByStudentNum(memberResDto.getStudentNum());
 
+        // 요청한 사용자의 학과가 존재한다면
         if (visitOptional.isPresent()) {
+            // 요청한 사용자의 학과 방문 데이터 업데이트
             Visit visit = (Visit) visitOptional.get();
             visit.addVisitor();
+            visit.setVisitRate(visit.getVisitor(), visit.getTotalStudent());
             visitRepository.save(visit);
+
+            // 방문하기 버튼을 누르기 위해선 로그인이 필수이므로 회원이 존재하지 않는 경우의 수는 고려하지 않음
+            // 요청한 사용자 방문 여부 true 로 변경
+            Member member = memberOptional.get();
+
+            // 방문 여부 true로 변경
+            member.visited();
+            memberRepository.save(member);
+
+            // 순위 업데이트 후 저장
+            calculateRankingByVisitRate();
+
+            return VisitResDto.builder()
+                    .username(member.getUsername())
+                    .major(member.getMajor())
+                    .visitRate(visit.getVisitRate())
+                    .rank(visit.getRanking())
+                    .build();
 
         } else { // 로그인한 회원의 학과가 존재하지 않는 경우
             throw new RuntimeException("존재하지 않는 학과입니다.");
         }
+    }
 
+    // 방문율을 기준으로 순위 산출
+    public void calculateRankingByVisitRate() {
+        List<Visit> allVisits = visitRepository.findAll();
+
+        // 방문율을 기준으로 내림차순 정렬
+        List<Visit> sortedVisits = allVisits.stream()
+                .sorted((v1, v2) -> {
+                    int compare = Long.compare(v2.getVisitRate(), v1.getVisitRate());
+                    if (compare == 0) {
+                        // 방문율이 동일한 경우에는 PK 내림차순으로 순위를 매김
+                        return Long.compare(v2.getId(), v1.getId());
+                    }
+                    return compare;
+                })
+                .collect(Collectors.toList());
+
+        // 순위 부여
+        int ranking = 1;
+        for (int i = 0; i < sortedVisits.size(); i++) {
+            Visit visit = sortedVisits.get(i);
+            if (i > 0 && visit.getVisitRate().equals(sortedVisits.get(i - 1).getVisitRate())) {
+                // 이전 방문 데이터와 방문율이 동일한 경우 이전 순위를 그대로 유지
+                visit.setRanking(sortedVisits.get(i - 1).getRanking());
+            } else {
+                visit.setRanking(ranking);
+            }
+            visitRepository.save(visit);
+            ranking++;
+        }
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/visit/domain/Visit.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/domain/Visit.java
@@ -29,24 +29,24 @@ public class Visit {
     // 방문률 산출
     private Long visitRate;
 
-    // 생성자 추가
-    // 모든 필드를 매개변수로 받는 생성자
-    public Visit (String major, Long visitor, Long totalStudent) {
-        this.major = major;
-        this.visitor = visitor;
-        this.totalStudent = totalStudent;
-        this.visitRate = calculateVisitRate(visitor, totalStudent);
-    }
+    // 방문율 순위
+    private int ranking;
+
 
     // 방문률 계산 메서드
-    private Long calculateVisitRate(Long visitor, Long totalStudent) {
+    public void setVisitRate(Long visitor, Long totalStudent) {
         if (totalStudent == 0) {
-            return 0L; // 분모가 0이면 방문률을 0으로 설정
+            this.visitRate = 0L;
+        } else {
+            this.visitRate = (visitor * 100) / totalStudent;
         }
-        return (visitor * 100) / totalStudent;
     }
 
     public void addVisitor() {
         visitor++;
+    }
+
+    public void setRanking(int ranking) {
+        this.ranking = ranking;
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/visit/domain/dto/VisitResDto.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/domain/dto/VisitResDto.java
@@ -1,0 +1,13 @@
+package likelion12th.SwuniForest.service.visit.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VisitResDto { // 방문하기 후 리턴할 방문율 dto
+    private String username;
+    private String major;
+    private Long visitRate;
+    private Integer rank;
+}


### PR DESCRIPTION
## 연관된 이슈
#3 #7

## 작업 내용
- 방문하기 api 호출 시 성공했다는 문자열만 반환했었는데 호출 후 바로 방문율 데이터가 반환되므로 dto 추가하여 데이터 반환하도록 수정
- 부스 운영진 초기 계정 생성 시 비밀번호 미리 지정하여 인코딩 후 저장하도록 수정
- 로그인 시 일반 유저와 부스 운영진 계정 구분하기 위해 로그인 성공 시 토큰 + 권한 스트링도 같이 반환하도록 dto 수정

## 리뷰 요구사항(선택)
