### PR TITLE
feat: 방문 여부 변경 없이 방문율 데이터 조회 api 추가

### DIFF
--- a/src/main/java/likelion12th/SwuniForest/config/SecurityConfig.java
+++ b/src/main/java/likelion12th/SwuniForest/config/SecurityConfig.java
@@ -64,11 +64,7 @@ public class SecurityConfig {
                 // 세션을 사용하지 않기 때문에 STATELESS로 설정
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
 
-                // enable h2-console
-                .headers(headers ->
-                        headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 );
 
         return http.build();

--- a/src/main/java/likelion12th/SwuniForest/db/DbInit.java
+++ b/src/main/java/likelion12th/SwuniForest/db/DbInit.java
@@ -10,22 +10,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import java.util.Random;
-
 @RequiredArgsConstructor
 @Component
 public class DbInit {
 
     private final MemberRepository memberRepository;
     private final VisitRepository visitRepository;
-
     private final PasswordEncoder passwordEncoder;
 
     @PostConstruct
     public void setDefaultData() {
         // 전체 학과 리스트
         String [] majorList = {
-                "dep1", "dep2", "dep3", "dep4", "dep5", "dep6", "dep7", "dep8", "dep9", "dep10",
+                "소프트웨어융합학과", "dep2", "dep3", "dep4", "dep5", "dep6", "dep7", "dep8", "dep9", "dep10",
                 "dep11", "dep12", "dep13", "dep14", "dep15", "dep16", "dep17", "dep18", "dep19",
                 "dep20", "dep21", "dep22", "dep23", "dep24", "dep25", "dep26", "dep27", "dep28",
                 "dep29", "dep30", "dep31", "dep32", "dep33", "dep34", "dep35"
@@ -45,9 +42,9 @@ public class DbInit {
 
         // 최상위 관리자 계정 생성
         Member admin = Member.builder()
-                .studentNum("2021111412") // 우선 내 학번으로 했음
+                .studentNum("likelion1212!!")
                 .username("admin")
-                .major("likelion12th")
+                .major("likelion")
                 .password(passwordEncoder.encode(adminPassword))
                 .role(Role.ROLE_ADMIN)
                 .build();
@@ -68,7 +65,7 @@ public class DbInit {
 
             // 학과별 부스 운영진 계정 생성
             Member manager = Member.builder()
-                    .studentNum(majorList[i]) // 영문학과명 + 숫자로 수정
+                    .studentNum(majorList[i]) // 영문학과명으로 수정
                     .major(majorList[i])
                     .password(passwordEncoder.encode(passwordList[i]))
                     .role(Role.ROLE_MANAGER)

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/guestbook/GuestbookController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/guestbook/GuestbookController.java
@@ -4,6 +4,8 @@ import likelion12th.SwuniForest.service.guestbook.GuestbookService;
 import likelion12th.SwuniForest.service.S3Service;
 import likelion12th.SwuniForest.service.guestbook.domain.dto.GuestbookDto;
 import likelion12th.SwuniForest.service.guestbook.repository.GuestbookRepository;
+import likelion12th.SwuniForest.service.member.MemberService;
+import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +20,6 @@ import java.util.List;
 @RequestMapping("/api/guestbook")
 public class GuestbookController {
 
-    private final GuestbookRepository guestbookRepository;
     private final GuestbookService guestbookService;
     private final S3Service s3Service;
 
@@ -60,4 +61,5 @@ public class GuestbookController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }
     }
+
 }

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/lostitem/LostitemController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/lostitem/LostitemController.java
@@ -4,6 +4,8 @@ import likelion12th.SwuniForest.service.S3Service;
 import likelion12th.SwuniForest.service.guestbook.domain.dto.GuestbookDto;
 import likelion12th.SwuniForest.service.lostitem.LostitemService;
 import likelion12th.SwuniForest.service.lostitem.domain.dto.LostitemDto;
+import likelion12th.SwuniForest.service.member.MemberService;
+import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -19,6 +22,7 @@ import java.util.List;
 public class LostitemController {
 
     private final LostitemService lostitemService;
+    private final MemberService memberService;
     private final S3Service s3Service;
 
     // 분실물 게시판 글 작성
@@ -49,10 +53,12 @@ public class LostitemController {
 
     // 분실물 게시판 글 전체 조회
     @GetMapping("/")
-    public ResponseEntity<List<LostitemDto>> getAllLostitem(){
+    public ResponseEntity getAllLostitem(){
         try {
             List<LostitemDto> lostitemList = lostitemService.getAllLostitem();
             return ResponseEntity.ok(lostitemList);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }

--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
@@ -10,20 +10,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api")
+@RequestMapping("/api/visit")
 public class VisitController {
 
     private final MemberService memberService;
     private final VisitService visitService;
 
     // 방문하기
-    @GetMapping("/visit")
+    @PostMapping("")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     public ResponseEntity visited() {
         MemberResDto memberResDto = memberService.getMyMemberInfo();
@@ -36,5 +37,14 @@ public class VisitController {
             // 방문하기 성공하면 방문율 데이터 dto 리턴
             return new ResponseEntity(visitResDto, HttpStatus.OK);
         }
+    }
+
+    // 방문율 데이터 불러오기
+    @GetMapping("/info")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
+    public ResponseEntity getVisitInfo() {
+        MemberResDto memberResDto = memberService.getMyMemberInfo();
+        VisitResDto visitResDto = visitService.getVisitinfo(memberResDto);
+        return new ResponseEntity(visitResDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/guestbook/GuestbookService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/guestbook/GuestbookService.java
@@ -7,6 +7,11 @@ import likelion12th.SwuniForest.service.member.MemberService;
 import likelion12th.SwuniForest.service.member.domain.Member;
 import likelion12th.SwuniForest.service.member.domain.Role;
 import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
+import likelion12th.SwuniForest.service.member.repository.MemberRepository;
+import likelion12th.SwuniForest.service.visit.VisitService;
+import likelion12th.SwuniForest.service.visit.domain.Visit;
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
+import likelion12th.SwuniForest.service.visit.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -22,6 +28,9 @@ import java.util.stream.Collectors;
 public class GuestbookService {
     private final GuestbookRepository guestbookRepository;
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final VisitRepository visitRepository;
+    private final VisitService visitService;
 
     // 방명록 작성
     @Transactional

--- a/src/main/java/likelion12th/SwuniForest/service/guestbook/domain/Guestbook.java
+++ b/src/main/java/likelion12th/SwuniForest/service/guestbook/domain/Guestbook.java
@@ -1,6 +1,7 @@
 package likelion12th.SwuniForest.service.guestbook.domain;
 
 import jakarta.persistence.*;
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,4 +32,6 @@ public class Guestbook {
     // 익명 여부
     @Column(nullable = false)
     private boolean anonymous;
+
+
 }

--- a/src/main/java/likelion12th/SwuniForest/service/guestbook/domain/dto/GuestbookDto.java
+++ b/src/main/java/likelion12th/SwuniForest/service/guestbook/domain/dto/GuestbookDto.java
@@ -1,5 +1,6 @@
 package likelion12th.SwuniForest.service.guestbook.domain.dto;
 
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,6 @@ public class GuestbookDto { // 방명록 작성 시 요청
     private String guestContent;
     private String fileName;
     private boolean anonymous;
-
 
     public String getGuestName() {
         return guestName;

--- a/src/main/java/likelion12th/SwuniForest/service/lostitem/LostitemService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/lostitem/LostitemService.java
@@ -5,12 +5,20 @@ import likelion12th.SwuniForest.service.guestbook.domain.dto.GuestbookDto;
 import likelion12th.SwuniForest.service.lostitem.domain.Lostitem;
 import likelion12th.SwuniForest.service.lostitem.domain.dto.LostitemDto;
 import likelion12th.SwuniForest.service.lostitem.repository.LostitemRepository;
+import likelion12th.SwuniForest.service.member.domain.Member;
+import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
+import likelion12th.SwuniForest.service.member.repository.MemberRepository;
+import likelion12th.SwuniForest.service.visit.VisitService;
+import likelion12th.SwuniForest.service.visit.domain.Visit;
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
+import likelion12th.SwuniForest.service.visit.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/likelion12th/SwuniForest/service/lostitem/domain/dto/LostitemDto.java
+++ b/src/main/java/likelion12th/SwuniForest/service/lostitem/domain/dto/LostitemDto.java
@@ -1,6 +1,7 @@
 package likelion12th.SwuniForest.service.lostitem.domain.dto;
 
 
+import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,4 +27,6 @@ public class LostitemDto {
 
     // 게시글 작성 시간
     private LocalDateTime createdAt;
+
+
 }


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
이전까지 방문하기 버튼 누르면 방문 여부 필드 true 로 변경하고 방문율 데이터 산출하여 리턴하는 api만 존재했었는데 
방문하기 상태 변경 후에 방명록 조회 시 상태변경 없이 방문율 데이터만 리턴하는 api가 존재하지 않아 추가하였다.

## 리뷰 요구사항(선택)

