### PR TITLE
feat: 방문율 데이터 조회, 방문율 랭킹 전체 조회 api 추가

### DIFF
--- a/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
+++ b/src/main/java/likelion12th/SwuniForest/presentation/controller/visit/VisitController.java
@@ -3,6 +3,7 @@ package likelion12th.SwuniForest.presentation.controller.visit;
 import likelion12th.SwuniForest.service.member.MemberService;
 import likelion12th.SwuniForest.service.visit.VisitService;
 import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
+import likelion12th.SwuniForest.service.visit.domain.dto.RankingDto;
 import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -24,7 +27,7 @@ public class VisitController {
     private final VisitService visitService;
 
     // 방문하기
-    @PostMapping("")
+    @PostMapping("/change")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     public ResponseEntity visited() {
         MemberResDto memberResDto = memberService.getMyMemberInfo();
@@ -46,5 +49,13 @@ public class VisitController {
         MemberResDto memberResDto = memberService.getMyMemberInfo();
         VisitResDto visitResDto = visitService.getVisitinfo(memberResDto);
         return new ResponseEntity(visitResDto, HttpStatus.OK);
+    }
+
+    // 방문율 전체 랭킹 조회 (권한 필요 없음)
+    @GetMapping("")
+    public ResponseEntity getVisitRanking() {
+
+        List<RankingDto> rankingDtoList = visitService.getVisitRanking();
+        return ResponseEntity.ok(rankingDtoList);
     }
 }

--- a/src/main/java/likelion12th/SwuniForest/service/visit/VisitService.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/VisitService.java
@@ -1,15 +1,18 @@
 package likelion12th.SwuniForest.service.visit;
 
+import likelion12th.SwuniForest.service.lostitem.domain.dto.LostitemDto;
 import likelion12th.SwuniForest.service.member.MemberService;
 import likelion12th.SwuniForest.service.member.domain.Member;
 import likelion12th.SwuniForest.service.member.domain.dto.MemberResDto;
 import likelion12th.SwuniForest.service.member.repository.MemberRepository;
 import likelion12th.SwuniForest.service.visit.domain.Visit;
+import likelion12th.SwuniForest.service.visit.domain.dto.RankingDto;
 import likelion12th.SwuniForest.service.visit.domain.dto.VisitResDto;
 import likelion12th.SwuniForest.service.visit.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -20,6 +23,22 @@ public class VisitService {
 
     private final MemberRepository memberRepository;
     private final VisitRepository visitRepository;
+
+    // 방문율 전체 랭킹 조회
+    public List<RankingDto> getVisitRanking() {
+        List<Visit> visitRankingList = visitRepository.findAllByOrderByVisitRateDesc();
+
+
+        List<RankingDto> rankingDtoList = visitRankingList.stream()
+                .map(visit -> RankingDto.builder()
+                        .major(visit.getMajor())
+                        .visitRate(visit.getVisitRate())
+                        .rank(visit.getRanking())
+                        .build())
+                .collect(Collectors.toList());
+
+        return rankingDtoList;
+    }
 
     // 방문율 데이터 가져오기
     // 방문 상태 변경 + 방문율 데이터 가져오기

--- a/src/main/java/likelion12th/SwuniForest/service/visit/domain/dto/RankingDto.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/domain/dto/RankingDto.java
@@ -1,0 +1,16 @@
+package likelion12th.SwuniForest.service.visit.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RankingDto {
+    private String major;
+    private Long visitRate;
+    private Integer rank;
+}

--- a/src/main/java/likelion12th/SwuniForest/service/visit/repository/VisitRepository.java
+++ b/src/main/java/likelion12th/SwuniForest/service/visit/repository/VisitRepository.java
@@ -3,8 +3,11 @@ package likelion12th.SwuniForest.service.visit.repository;
 import likelion12th.SwuniForest.service.visit.domain.Visit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
     Optional<Visit> findByMajor(String major);
+
+    List<Visit> findAllByOrderByVisitRateDesc();
 }


### PR DESCRIPTION
## 연관된 이슈
#7 

## 작업 내용
- 로그인 O -> 방문하기 O 인 사용자가 방명록 페이지 조회 시 방문율 데이터 조회 api 추가
- 방문율 랭킹 전체 보기 페이지에 사용될 방문율 내림차순 전체 조회 api 추가

## 리뷰 요구사항(선택)

